### PR TITLE
convert FETCH_COOKIES requests to use curl for better authentication support

### DIFF
--- a/wp-pdf-templates.php
+++ b/wp-pdf-templates.php
@@ -207,47 +207,47 @@ function _use_pdf_template() {
 
       if( defined('FETCH_COOKIES_ENABLED') && FETCH_COOKIES_ENABLED ) {
 
-		$url =  $link . (strpos($link, '?') === false ? '?' : '&') . 'pdf-template';
-		$ch = curl_init();
-		
-		curl_setopt($ch, CURLOPT_URL, $url);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		
-		// get http headers for cookies
-		curl_setopt($ch, CURLOPT_VERBOSE, 1);
-		curl_setopt($ch, CURLOPT_HEADER, 1);
-		
-		// store the cookies
-		$cookies = array();
-		foreach ($_COOKIE as $key => $value)
-		{
-			if ($key != 'Array')
-			{
-				$cookies[] = $key . '=' . $value;
-			}
-		}
-		// add the cookies to the request
-		curl_setopt( $ch, CURLOPT_COOKIE, implode(';', $cookies) );
-		
-		// Stop session so curl can use the same session without conflicts
-		session_write_close();
-		
-		$response = curl_exec($ch);
-		curl_close($ch);
-		
-		// Session restart
-		session_start();
-		
-		// Seperate header and body
-		list($header, $body) = explode("\r\n\r\n", $response, 2);
-		
-		// extract cookies form curl and forward them to browser
-		preg_match_all('/^(Set-Cookie:\s*[^\n]*)$/mi', $header, $cookies);
-		foreach($cookies[0] AS $cookie){
-		  header($cookie, false);
-		}
-	   
-		$html = $body;
+        $url =  $link . (strpos($link, '?') === false ? '?' : '&') . 'pdf-template';
+        $ch = curl_init();
+        
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        
+        // get http headers for cookies
+        curl_setopt($ch, CURLOPT_VERBOSE, 1);
+        curl_setopt($ch, CURLOPT_HEADER, 1);
+        
+        // store the cookies
+        $cookies = array();
+        foreach ($_COOKIE as $key => $value)
+        {
+            if ($key != 'Array')
+            {
+                $cookies[] = $key . '=' . $value;
+            }
+        }
+        // add the cookies to the request
+        curl_setopt( $ch, CURLOPT_COOKIE, implode(';', $cookies) );
+        
+        // Stop session so curl can use the same session without conflicts
+        session_write_close();
+        
+        $response = curl_exec($ch);
+        curl_close($ch);
+        
+        // Session restart
+        session_start();
+        
+        // Seperate header and body
+        list($header, $body) = explode("\r\n\r\n", $response, 2);
+        
+        // extract cookies form curl and forward them to browser
+        preg_match_all('/^(Set-Cookie:\s*[^\n]*)$/mi', $header, $cookies);
+        foreach($cookies[0] AS $cookie){
+          header($cookie, false);
+        }
+       
+        $html = $body;
       }
 
       else {

--- a/wp-pdf-templates.php
+++ b/wp-pdf-templates.php
@@ -207,48 +207,47 @@ function _use_pdf_template() {
 
       if( defined('FETCH_COOKIES_ENABLED') && FETCH_COOKIES_ENABLED ) {
 
-		 $cookie_jar = tempnam('/tmp','cookie');
-		 $url =  $link . (strpos($link, '?') === false ? '?' : '&') . 'pdf-template';
-		 $ch = curl_init();
-		 
-		 curl_setopt($ch, CURLOPT_URL, $url);
-		 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-		 
-		 // get http headers for cookies
-		 curl_setopt($ch, CURLOPT_VERBOSE, 1);
-		 curl_setopt($ch, CURLOPT_HEADER, 1);
-		 
-		 // store the cookies
-		 $cookies = array();
-		 foreach ($_COOKIE as $key => $value)
-		 {
-			 if ($key != 'Array')
-			 {
-				 $cookies[] = $key . '=' . $value;
-			 }
-		 }
-		 // add the cookies to the request
-		 curl_setopt( $ch, CURLOPT_COOKIE, implode(';', $cookies) );
-		 
-		 // Stop session so curl can use the same session without conflicts
-		 session_write_close();
-		 
-		 $response = curl_exec($ch);
-		 curl_close($ch);
-		 
-		 // Session restart
-		 session_start();
-		 
-		 // Seperate header and body
-		 list($header, $body) = explode("\r\n\r\n", $response, 2);
-		 
-		 // extract cookies form curl and forward them to browser
-		 preg_match_all('/^(Set-Cookie:\s*[^\n]*)$/mi', $header, $cookies);
-		 foreach($cookies[0] AS $cookie){
-		   header($cookie, false);
-		 }
-
-		 $html = $body;
+		$url =  $link . (strpos($link, '?') === false ? '?' : '&') . 'pdf-template';
+		$ch = curl_init();
+		
+		curl_setopt($ch, CURLOPT_URL, $url);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		
+		// get http headers for cookies
+		curl_setopt($ch, CURLOPT_VERBOSE, 1);
+		curl_setopt($ch, CURLOPT_HEADER, 1);
+		
+		// store the cookies
+		$cookies = array();
+		foreach ($_COOKIE as $key => $value)
+		{
+			if ($key != 'Array')
+			{
+				$cookies[] = $key . '=' . $value;
+			}
+		}
+		// add the cookies to the request
+		curl_setopt( $ch, CURLOPT_COOKIE, implode(';', $cookies) );
+		
+		// Stop session so curl can use the same session without conflicts
+		session_write_close();
+		
+		$response = curl_exec($ch);
+		curl_close($ch);
+		
+		// Session restart
+		session_start();
+		
+		// Seperate header and body
+		list($header, $body) = explode("\r\n\r\n", $response, 2);
+		
+		// extract cookies form curl and forward them to browser
+		preg_match_all('/^(Set-Cookie:\s*[^\n]*)$/mi', $header, $cookies);
+		foreach($cookies[0] AS $cookie){
+		  header($cookie, false);
+		}
+	   
+		$html = $body;
       }
 
       else {

--- a/wp-pdf-templates.php
+++ b/wp-pdf-templates.php
@@ -207,24 +207,48 @@ function _use_pdf_template() {
 
       if( defined('FETCH_COOKIES_ENABLED') && FETCH_COOKIES_ENABLED ) {
 
-        // we want a html template
-        $header = 'Accept:text/html' . "\n";
+		 $cookie_jar = tempnam('/tmp','cookie');
+		 $url =  $link . (strpos($link, '?') === false ? '?' : '&') . 'pdf-template';
+		 $ch = curl_init();
+		 
+		 curl_setopt($ch, CURLOPT_URL, $url);
+		 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		 
+		 // get http headers for cookies
+		 curl_setopt($ch, CURLOPT_VERBOSE, 1);
+		 curl_setopt($ch, CURLOPT_HEADER, 1);
+		 
+		 // store the cookies
+		 $cookies = array();
+		 foreach ($_COOKIE as $key => $value)
+		 {
+			 if ($key != 'Array')
+			 {
+				 $cookies[] = $key . '=' . $value;
+			 }
+		 }
+		 // add the cookies to the request
+		 curl_setopt( $ch, CURLOPT_COOKIE, implode(';', $cookies) );
+		 
+		 // Stop session so curl can use the same session without conflicts
+		 session_write_close();
+		 
+		 $response = curl_exec($ch);
+		 curl_close($ch);
+		 
+		 // Session restart
+		 session_start();
+		 
+		 // Seperate header and body
+		 list($header, $body) = explode("\r\n\r\n", $response, 2);
+		 
+		 // extract cookies form curl and forward them to browser
+		 preg_match_all('/^(Set-Cookie:\s*[^\n]*)$/mi', $header, $cookies);
+		 foreach($cookies[0] AS $cookie){
+		   header($cookie, false);
+		 }
 
-        // pass cookies from current request
-        if( isset( $_SERVER['HTTP_COOKIE'] ) ) {
-          $header .= 'Cookie: ' . $_SERVER['HTTP_COOKIE'] . "\n";
-        }
-
-        // create a request context for file_get_contents
-        $context = stream_context_create(array(
-          'http' => array(
-            'method' => 'GET',
-            'header' => $header,
-          )
-        ));
-
-        // load the generated html from the template endpoint
-        $html = file_get_contents($link . (strpos($link, '?') === false ? '?' : '&') . 'pdf-template', false, $context);
+		 $html = $body;
       }
 
       else {

--- a/wp-pdf-templates.php
+++ b/wp-pdf-templates.php
@@ -219,10 +219,8 @@ function _use_pdf_template() {
         
         // store the cookies
         $cookies = array();
-        foreach ($_COOKIE as $key => $value)
-        {
-            if ($key != 'Array')
-            {
+        foreach ($_COOKIE as $key => $value) {
+            if ($key != 'Array') {
                 $cookies[] = $key . '=' . $value;
             }
         }
@@ -243,7 +241,7 @@ function _use_pdf_template() {
         
         // extract cookies form curl and forward them to browser
         preg_match_all('/^(Set-Cookie:\s*[^\n]*)$/mi', $header, $cookies);
-        foreach($cookies[0] AS $cookie){
+        foreach($cookies[0] AS $cookie) {
           header($cookie, false);
         }
        


### PR DESCRIPTION
The original file_get_contents method wasn't passing all the cookies needed to render private/authenticated content. I tried converting it to use curl and it worked, so here are my changes for your consideration.

Credit to stackoverflow user **PiTheNumber** for the curl example I started with (http://stackoverflow.com/a/23907823/3735757).
