### PR TITLE
Fixing Issue 17

### DIFF
--- a/wp-pdf-templates.php
+++ b/wp-pdf-templates.php
@@ -208,8 +208,16 @@ function _use_pdf_template() {
     $url = parse_url(get_the_permalink());
 
     // we use localhost to make sure we're requesting the page from this wordpress instance
+
     $link = $url['scheme'] . '://localhost' . $url['path'];
     $link = $link . (strpos($link, '?') === false ? '?' : '&') . 'pdf-template';
+
+    // checking to make sure that localhost is writable because
+    // it won't be in many shared hosting environments
+    if (!is_writable($link)) {
+      $link = get_the_permalink();
+      $link = $link . (strpos($link, '?') === false ? '?' : '&') . 'pdf-template';
+    }
 
     if(isset($wp_query->query_vars['pdf']) || isset($wp_query->query_vars['pdf-preview'])) {
 


### PR DESCRIPTION
This fixes Issue 17 (https://github.com/anttiviljami/wp-pdf-templates/issues/17) where $html is not empty, but localhost is not writable, which leads to blank PDFs. This is most likely to happen on shared hosting environments where localhost is not configured correctly. 
