### PR TITLE
Sanitize filename

### DIFF
--- a/wp-pdf-templates.php
+++ b/wp-pdf-templates.php
@@ -331,8 +331,9 @@ function _print_pdf($html) {
   if (isset($wp_query->query_vars['pdf'])) {
     // convert to PDF
 
-    $filename = get_the_title() . '.pdf';
-    $cached = PDF_CACHE_DIRECTORY . get_the_title() . '-' . substr(md5(get_the_modified_time()), -6) . '.pdf';
+    $title_sanitized = sanitize_file_name( get_the_title() );
+    $cached = PDF_CACHE_DIRECTORY . get_the_title() . '-' . substr(md5(get_the_modified_time()), -6) . '.pdf';		+    $filename = $title_sanitized . '.pdf';
+    $cached = PDF_CACHE_DIRECTORY . $title_sanitized . '-' . substr(md5(get_the_modified_time()), -6) . '.pdf';
 
     // check if we need to generate PDF against cache
     if(( defined('DISABLE_PDF_CACHE') && DISABLE_PDF_CACHE ) || ( isset($_SERVER['HTTP_PRAGMA']) && $_SERVER['HTTP_PRAGMA'] == 'no-cache' ) || !file_exists($cached) ) {

--- a/wp-pdf-templates.php
+++ b/wp-pdf-templates.php
@@ -332,7 +332,7 @@ function _print_pdf($html) {
     // convert to PDF
 
     $title_sanitized = sanitize_file_name( get_the_title() );
-    $cached = PDF_CACHE_DIRECTORY . get_the_title() . '-' . substr(md5(get_the_modified_time()), -6) . '.pdf';		+    $filename = $title_sanitized . '.pdf';
+    $filename = $title_sanitized . '.pdf';
     $cached = PDF_CACHE_DIRECTORY . $title_sanitized . '-' . substr(md5(get_the_modified_time()), -6) . '.pdf';
 
     // check if we need to generate PDF against cache


### PR DESCRIPTION
Cache file saving fails if the post title has special characters that are illegal in filenames on certain operating systems.