### PR TITLE
Add filters to modify filename and cache id

### DIFF
--- a/wp-pdf-templates.php
+++ b/wp-pdf-templates.php
@@ -331,9 +331,15 @@ function _print_pdf($html) {
   if (isset($wp_query->query_vars['pdf'])) {
     // convert to PDF
 
-    $title_sanitized = sanitize_file_name( get_the_title() );
-    $filename = $title_sanitized . '.pdf';
-    $cached = PDF_CACHE_DIRECTORY . $title_sanitized . '-' . substr(md5(get_the_modified_time()), -6) . '.pdf';
+    $filename = sanitize_file_name(get_the_title());
+    $cache_id = substr(md5(get_the_modified_time()), -6);
+
+    $filename = apply_filters('pdf_template_filename', $filename);
+    $cache_id = apply_filters('pdf_template_cache_id', $cache_id);
+
+    $cached = PDF_CACHE_DIRECTORY . $filename . '-' . $cache_id . '.pdf';
+
+    $filename .= '.pdf';
 
     // check if we need to generate PDF against cache
     if(( defined('DISABLE_PDF_CACHE') && DISABLE_PDF_CACHE ) || ( isset($_SERVER['HTTP_PRAGMA']) && $_SERVER['HTTP_PRAGMA'] == 'no-cache' ) || !file_exists($cached) ) {
@@ -404,4 +410,3 @@ function _print_pdf($html) {
   die();
 
 }
-


### PR DESCRIPTION
I had a situation where the product names (and slugs) were identical across different languages and as a result the PDFs were cached and served in wrong translations. Also, it became necessary to customize the filename more specifically, adding info from post metadata etc.

This PR adds two filters to customize the pdf filename: the actual name and the cache id which is used to determine if the file should be generated.

Example use:

```
add_filter('pdf_template_filename', function( $filename ) {

	$type_translations = [
		'fi' => 'tuotekortti',
		'en' => 'product-data',
		'de' => 'produktblad',
		'sv' => 'produktkarte'
	];

	$type = isset( $type_translations[ pll_current_language() ] ) ? $type_translations[ pll_current_language() ] : null;

	if ( $type ) {
		$title = sanitize_file_name( get_the_title() );
		$version = get_field('product__version');
		$filename = "{$type}-{$title}-{$version}";
	}

	return $filename;

}, 10, 2);
```

```
add_filter('pdf_template_cache_id', function( $cache_id ) {
	return get_the_modified_time('U'); // use unix timestamp as cache id
}, 10, 2);
```